### PR TITLE
Azure has changed how SasToken should be computed.

### DIFF
--- a/iothub/rest.go
+++ b/iothub/rest.go
@@ -156,6 +156,7 @@ func (c *IotHubHTTPClient) ReceiveMessage() (string, string) {
 
 func (c *IotHubHTTPClient) buildSasToken(uri string) string {
 	timestamp := time.Now().Unix() + int64(3600)
+	uri = strings.Split(uri,"/")[0]
 	encodedURI := template.URLQueryEscaper(uri)
 
 	toSign := encodedURI + "\n" + strconv.FormatInt(timestamp, 10)


### PR DESCRIPTION
Microsoft changed how Shared Access Signature is supposed to be computed. It used to take ".azure-devices.net/devices/?api-version=2016-11-14" for the computation, since March 18/19, the new way of computing would take just the "".azure-devices.net/devices/" part. If we don't make this change, Azure just returns 500 Internal Server Error.